### PR TITLE
Manage query with full body

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,16 @@
 {
   "extends": "airbnb",
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true,
   },
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"
+  },
+  "rules": {
+    "import/prefer-default-export": ["off"],
+    "no-plusplus": ["off"],
+    "no-console": ["off"]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": "airbnb",
   "env": {
     "node": true
   },

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ yarn add gatsby-source-elasticsearch
 | connection | Connection details | string, object |
 | index | The index to query against | string |
 | typeName | The type name to generate in Gatsby | string |
-| query | The query to run | string, object |
+| query | The query as query string to run | string, object |
+| body | The [query body](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html) to run | object |
 | scrollDuration | Scroll duration (default: 30s) | string |
 | scrollSize | Scroll size (default: 1000) | integer |
+
+*Fields `query` and `body` are mutually exclusive.*
 
 For more information on `scrollDuration` and `scrollSize`, check out the [Scroll documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html). `scrollDuration` maps to the `scroll` parameter in the documentation, and `scrollSize` to `size`.
 

--- a/query.js
+++ b/query.js
@@ -6,27 +6,36 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-exports.default = query;
-function query(options) {
-  let result = {
-    index: options.index,
-    scroll: options.scrollDuration || '30s',
-    size: options.scrollSize || 1000
+const isString = data => typeof data === 'string';
+
+const isObject = data => typeof data === 'object';
+
+exports.default = ({ index, scrollDuration, scrollSize, query, body }) => {
+  const result = {
+    index,
+    scroll: scrollDuration || '30s',
+    size: scrollSize || 1000
   };
 
-  if (typeof options.query === 'object') {
+  if (isObject(body)) {
+    return _extends({}, result, {
+      body: body
+    });
+  }
+
+  if (isObject(query)) {
     return _extends({}, result, {
       body: {
-        query: options.query
+        query
       }
     });
   }
 
-  if (typeof options.query === 'string') {
+  if (isString(query)) {
     return _extends({}, result, {
-      q: options.query
+      q: query
     });
   }
 
   return result;
-}
+};

--- a/query.js
+++ b/query.js
@@ -3,6 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 exports.default = query;
 function query(options) {
   let result = {
@@ -11,8 +14,17 @@ function query(options) {
     size: options.scrollSize || 1000
   };
 
-  if (typeof options.query === 'object') Object.assign(result, { body: { query: options.query } });
-  if (typeof options.query === 'string') Object.assign(result, { q: options.query });
+  if (typeof options.query === 'object') {
+    return _extends({}, result, {
+      body: _extends({}, options.query)
+    });
+  }
+
+  if (typeof options.query === 'string') {
+    return _extends({}, result, {
+      q: options.query
+    });
+  }
 
   return result;
 }

--- a/query.js
+++ b/query.js
@@ -16,7 +16,9 @@ function query(options) {
 
   if (typeof options.query === 'object') {
     return _extends({}, result, {
-      body: _extends({}, options.query)
+      body: {
+        query: options.query
+      }
     });
   }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -52,8 +52,8 @@ export async function sourceNodes({ boundActionCreators }, options) {
 
     // Continue scroll query
     responseQueue.push(
-      await client.scroll({
-        scrollId: response._scroll_id,
+      await client.scroll({ // eslint-disable-line no-await-in-loop
+        scrollId: response._scroll_id, // eslint-disable-line no-underscore-dangle
         scroll: '30s',
       }),
     );

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -5,7 +5,7 @@ import validation from './validation'
 
 const createContentDigest = obj => crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex');
 
-export async function sourceNodes({ boundActionCreators }, options) {
+export async function sourceNodes ({ boundActionCreators }, options) {
   const { createNode } = boundActionCreators;
 
   if (!validation(options)) return;
@@ -15,7 +15,7 @@ export async function sourceNodes({ boundActionCreators }, options) {
   if (typeof options.connection === 'object') clientOptions = options.connection;
 
   const client = new elasticsearch.Client(clientOptions);
-  
+
   // Start scroll with initial query
   let totalProcessed = 0;
   const responseQueue = [];
@@ -27,7 +27,7 @@ export async function sourceNodes({ boundActionCreators }, options) {
     const response = responseQueue.shift();
 
     // create nodes from the documents in the response
-    response.hits.hits.forEach(function (hit) {
+    response.hits.hits.forEach(hit => {
       const { _id, _source } = hit;
 
       createNode({
@@ -35,9 +35,9 @@ export async function sourceNodes({ boundActionCreators }, options) {
         id: _id,
         parent: null,
         children: [],
-        internal: { 
-          type: options.typeName, 
-          contentDigest: createContentDigest(_source) 
+        internal: {
+          type: options.typeName,
+          contentDigest: createContentDigest(_source)
         }
       });
 

--- a/src/query.js
+++ b/src/query.js
@@ -5,8 +5,21 @@ export default function query(options) {
     size: options.scrollSize || 1000,
   }
 
-  if (typeof options.query === 'object') Object.assign(result, { body: { query: options.query } })
-  if (typeof options.query === 'string') Object.assign(result, { q: options.query })
+  if (typeof options.query === 'object') {
+    return {
+      ...result,
+      body: {
+        ...options.query,
+      },
+    };
+  }
+
+  if (typeof options.query === 'string') {
+    return {
+      ...result,
+      q: options.query,
+    };
+  }
 
   return result;
 }

--- a/src/query.js
+++ b/src/query.js
@@ -1,23 +1,36 @@
-export default function query(options) {
-  let result = {
-    index: options.index,
-    scroll: options.scrollDuration || '30s',
-    size: options.scrollSize || 1000,
+const isString = data =>
+  typeof data === 'string';
+
+const isObject = data =>
+  typeof data === 'object';
+
+export default ({ index, scrollDuration, scrollSize, query, body }) => {
+  const result = {
+    index,
+    scroll: scrollDuration || '30s',
+    size: scrollSize || 1000,
   }
 
-  if (typeof options.query === 'object') {
+  if (isObject(body)) {
+    return {
+      ...result,
+      body: body,
+    }
+  }
+
+  if (isObject(query)) {
     return {
       ...result,
       body: {
-        query: options.query,
+        query,
       },
     };
   }
 
-  if (typeof options.query === 'string') {
+  if (isString(query)) {
     return {
       ...result,
-      q: options.query,
+      q: query,
     };
   }
 

--- a/src/query.js
+++ b/src/query.js
@@ -9,7 +9,7 @@ export default function query(options) {
     return {
       ...result,
       body: {
-        ...options.query,
+        query: options.query,
       },
     };
   }

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -27,9 +27,7 @@ describe('Query Builder', function() {
   it('builds an object query', function() {
     const options = {
       index: 'testIndex',
-      query: {
-        query: { test: 'query' }
-      }
+      query: { test: 'query' },
     }
 
     assert.deepEqual(query(options), { 

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -27,7 +27,9 @@ describe('Query Builder', function() {
   it('builds an object query', function() {
     const options = {
       index: 'testIndex',
-      query: { test: 'query' }
+      query: {
+        query: { test: 'query' }
+      }
     }
 
     assert.deepEqual(query(options), { 

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import query from './query'
 
-describe('Query Builder', function() {
-  it('builds an empty query', function() {
+describe('Query Builder', () => {
+  it('builds an empty query', () => {
     const options = {
       index: 'testIndex',
     }
@@ -10,29 +10,29 @@ describe('Query Builder', function() {
     assert.deepEqual(query(options), { index: 'testIndex', scroll: '30s', size: 1000 })
   });
 
-  it('builds a string query', function() {
+  it('builds a string query', () => {
     const options = {
       index: 'testIndex',
       query: 'test query'
     }
 
-    assert.deepEqual(query(options), { 
-      index: 'testIndex', 
-      scroll: '30s', 
+    assert.deepEqual(query(options), {
+      index: 'testIndex',
+      scroll: '30s',
       size: 1000,
       q: 'test query',
     })
   });
 
-  it('builds an object query', function() {
+  it('builds an object query', () => {
     const options = {
       index: 'testIndex',
       query: { test: 'query' },
     }
 
-    assert.deepEqual(query(options), { 
-      index: 'testIndex', 
-      scroll: '30s', 
+    assert.deepEqual(query(options), {
+      index: 'testIndex',
+      scroll: '30s',
       size: 1000,
       body: {
         query: {
@@ -42,7 +42,7 @@ describe('Query Builder', function() {
     })
   });
 
-  it('builds an object query body', function() {
+  it('builds an object query body', () => {
     const options = {
       index: 'testIndex',
       body: { query: { test: 'query' } },
@@ -60,7 +60,7 @@ describe('Query Builder', function() {
     })
   });
 
-  it('sets the scroll size', function() {
+  it('sets the scroll size', () => {
     const options = {
       index: 'testIndex',
       scrollSize: 555,
@@ -69,7 +69,7 @@ describe('Query Builder', function() {
     assert.deepEqual(query(options), { index: 'testIndex', scroll: '30s', size: 555 })
   });
 
-  it('sets the scroll duration', function() {
+  it('sets the scroll duration', () => {
     const options = {
       index: 'testIndex',
       scrollDuration: '1m',

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -1,34 +1,34 @@
-import assert from 'assert'
-import query from './query'
+import assert from 'assert';
+import query from './query';
 
 describe('Query Builder', () => {
   it('builds an empty query', () => {
     const options = {
       index: 'testIndex',
-    }
+    };
 
-    assert.deepEqual(query(options), { index: 'testIndex', scroll: '30s', size: 1000 })
+    assert.deepEqual(query(options), { index: 'testIndex', scroll: '30s', size: 1000 });
   });
 
   it('builds a string query', () => {
     const options = {
       index: 'testIndex',
-      query: 'test query'
-    }
+      query: 'test query',
+    };
 
     assert.deepEqual(query(options), {
       index: 'testIndex',
       scroll: '30s',
       size: 1000,
       q: 'test query',
-    })
+    });
   });
 
   it('builds an object query', () => {
     const options = {
       index: 'testIndex',
       query: { test: 'query' },
-    }
+    };
 
     assert.deepEqual(query(options), {
       index: 'testIndex',
@@ -36,17 +36,17 @@ describe('Query Builder', () => {
       size: 1000,
       body: {
         query: {
-          test: "query"
-        }
-      }
-    })
+          test: 'query',
+        },
+      },
+    });
   });
 
   it('builds an object query body', () => {
     const options = {
       index: 'testIndex',
       body: { query: { test: 'query' } },
-    }
+    };
 
     assert.deepEqual(query(options), {
       index: 'testIndex',
@@ -54,27 +54,27 @@ describe('Query Builder', () => {
       size: 1000,
       body: {
         query: {
-          test: "query"
-        }
-      }
-    })
+          test: 'query',
+        },
+      },
+    });
   });
 
   it('sets the scroll size', () => {
     const options = {
       index: 'testIndex',
       scrollSize: 555,
-    }
+    };
 
-    assert.deepEqual(query(options), { index: 'testIndex', scroll: '30s', size: 555 })
+    assert.deepEqual(query(options), { index: 'testIndex', scroll: '30s', size: 555 });
   });
 
   it('sets the scroll duration', () => {
     const options = {
       index: 'testIndex',
       scrollDuration: '1m',
-    }
+    };
 
-    assert.deepEqual(query(options), { index: 'testIndex', scroll: '1m', size: 1000 })
+    assert.deepEqual(query(options), { index: 'testIndex', scroll: '1m', size: 1000 });
   });
 });

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -42,6 +42,24 @@ describe('Query Builder', function() {
     })
   });
 
+  it('builds an object query body', function() {
+    const options = {
+      index: 'testIndex',
+      body: { query: { test: 'query' } },
+    }
+
+    assert.deepEqual(query(options), {
+      index: 'testIndex',
+      scroll: '30s',
+      size: 1000,
+      body: {
+        query: {
+          test: "query"
+        }
+      }
+    })
+  });
+
   it('sets the scroll size', function() {
     const options = {
       index: 'testIndex',

--- a/src/validation.js
+++ b/src/validation.js
@@ -7,14 +7,14 @@ const isValidString = data =>
 const isObject = data =>
   typeof data === 'object';
 
-export default function validation ({
+const validator = ({
   typeName,
   connection,
   index,
   query,
   scrollDuration,
   scrollSize
-}) {
+}) => {
   const errors = [];
 
   if (!isValidString(typeName)) {
@@ -41,6 +41,12 @@ export default function validation ({
     errors.push('Error: "scrollSize" must be a number');
   }
 
+  return errors;
+}
+
+export const validation = options => {
+  const errors = validator(options);
+
   if (errors.length) {
     errors.forEach(error => console.log(error));
     return false;
@@ -48,3 +54,5 @@ export default function validation ({
 
   return true;
 }
+
+export default validation;

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,30 +1,39 @@
+const isString = data =>
+  typeof data === 'string';
+
+const isEmptyString = data =>
+  data === '';
+
+const isObject = data =>
+  typeof data === 'object';
+
 export default function validation(options) {
   if (options.typeName == null
-    || (typeof options.typeName !== 'string' || options.typeName === '')) {
+    || (!isString(options.typeName) || isEmptyString(options.typeName))) {
     console.log('Error: "typeName" option is required');
     return false;
   }
 
   if (options.connection == null
-    || ((typeof options.connection === 'string' && options.connection === '') && typeof options.connection !== 'object')) {
+    || ((isString(options.connection) && isEmptyString(options.connection)) && !isObject(options.connection))) {
     console.log('Error: "connection" option must either be a non-empty string or an object');
     return false;
   }
 
   if (options.index == null
-    || (typeof options.index !== 'string' || options.index === '')) {
+    || (!isString(options.index) || isEmptyString(options.index))) {
     console.log('Error: "index" option is required');
     return false;
   }
 
   if (options.query == null
-    || (typeof options.query !== 'string' && typeof options.query !== 'object')) {
+    || (!isString(options.query) && !isObject(options.query))) {
     console.log('Error: "query" must either be a string or an object');
     return false;
   }
 
   if (options.scrollDuration
-    && (typeof options.scrollDuration !== 'string')) {
+    && (!isString(options.scrollDuration))) {
     console.log('Error: "scrollDuration" must be a duration string (i.e. 1s, 10s, 1m)');
     return false;
   }

--- a/src/validation.js
+++ b/src/validation.js
@@ -55,4 +55,6 @@ export const validation = options => {
   return true;
 }
 
+export const isValid = options => !validator(options).length;
+
 export default validation;

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,46 +1,48 @@
 const isString = data =>
   typeof data === 'string';
 
-const isEmptyString = data =>
-  data === '';
+const isValidString = data =>
+  isString(data) && data.length > 0;
 
 const isObject = data =>
   typeof data === 'object';
 
-export default function validation(options) {
-  if (options.typeName == null
-    || (!isString(options.typeName) || isEmptyString(options.typeName))) {
-    console.log('Error: "typeName" option is required');
-    return false;
+export default function validation ({
+  typeName,
+  connection,
+  index,
+  query,
+  scrollDuration,
+  scrollSize
+}) {
+  const errors = [];
+
+  if (!isValidString(typeName)) {
+    errors.push('Error: "typeName" option is required');
   }
 
-  if (options.connection == null
-    || ((isString(options.connection) && isEmptyString(options.connection)) && !isObject(options.connection))) {
-    console.log('Error: "connection" option must either be a non-empty string or an object');
-    return false;
+  if (!connection || !(isValidString(connection) || isObject(connection))) {
+    errors.push('Error: "connection" option must either be a non-empty string or an object');
   }
 
-  if (options.index == null
-    || (!isString(options.index) || isEmptyString(options.index))) {
-    console.log('Error: "index" option is required');
-    return false;
+  if (!isValidString(index)) {
+    errors.push('Error: "index" option is required');
   }
 
-  if (options.query == null
-    || (!isString(options.query) && !isObject(options.query))) {
-    console.log('Error: "query" must either be a string or an object');
-    return false;
+  if (query === null || !(isString(query) || isObject(query))) {
+    errors.push('Error: "query" must either be a string or an object');
   }
 
-  if (options.scrollDuration
-    && (!isString(options.scrollDuration))) {
-    console.log('Error: "scrollDuration" must be a duration string (i.e. 1s, 10s, 1m)');
-    return false;
+  if (scrollDuration && !isValidString(scrollDuration)) {
+    errors.push('Error: "scrollDuration" must be a duration string (i.e. 1s, 10s, 1m)');
   }
 
-  if (options.scrollSize
-    && (isNaN(parseFloat(options.scrollSize)) && !isFinite(options.scrollSize))) {
-    console.log('Error: "scrollSize" must be a number');
+  if (scrollSize && !isFinite(scrollSize)) {
+    errors.push('Error: "scrollSize" must be a number');
+  }
+
+  if (errors.length) {
+    errors.forEach(error => console.log(error));
     return false;
   }
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -7,11 +7,15 @@ const isValidString = data =>
 const isObject = data =>
   typeof data === 'object';
 
-const validator = ({
+const isDefined = data =>
+  typeof data !== 'undefined';
+
+export const validator = ({
   typeName,
   connection,
   index,
   query,
+  body,
   scrollDuration,
   scrollSize
 }) => {
@@ -29,8 +33,20 @@ const validator = ({
     errors.push('Error: "index" option is required');
   }
 
-  if (query === null || !(isString(query) || isObject(query))) {
+  if (isString(query) && isObject(query) || (query === null && !isDefined(body))) {
     errors.push('Error: "query" must either be a string or an object');
+  }
+
+  if (isDefined(query) && isDefined(body)) {
+    errors.push('Error: "query" and "body" are mutually exclusive');
+  }
+
+  if (!isDefined(query) && !isDefined(body)) {
+    errors.push('Error: "query" or "body" is required');
+  }
+
+  if (isDefined(body) && !isObject(body) || (body === null && !isDefined(query))) {
+    errors.push('Error: "body" should be an object');
   }
 
   if (scrollDuration && !isValidString(scrollDuration)) {

--- a/src/validation.test.js
+++ b/src/validation.test.js
@@ -1,5 +1,7 @@
 import assert from 'assert'
-import validation from './validation'
+import { isValid } from './validation'
+
+const validation = isValid;
 
 describe('Options Validation', function() {
   const validOptions = {

--- a/src/validation.test.js
+++ b/src/validation.test.js
@@ -49,12 +49,34 @@ describe('Options Validation', () => {
 
   });
 
-  describe('Validates the query field', () => {
+  describe('Validates the body and query fields concurrence', () => {
     const options = { ...validOptions };
     delete options.query;
 
-    // it('Fails with no query', () =>
-    //   assert.equal(validation(options), false));
+    it('Fails with query and body', () =>
+      assert.equal(validation({ ...options, query: '', body: {} }), false));
+
+    it('Fails with no query neither body', () =>
+      assert.equal(validation({ ...options }), false));
+
+  });
+
+  describe('Validates the body field', () => {
+    const options = { ...validOptions };
+    delete options.query;
+
+    it('Fails with null', () =>
+      assert.equal(validation({ ...options, body: null }), false));
+
+    it('Fails with not-an-object', () =>
+      assert.equal(validation({ ...options, body: '' }), false));
+
+    it('Succeed with object', () =>
+      assert.equal(validation({ ...options, body: { test: 'this' } }), true));
+  });
+
+  describe('Validates the query field', () => {
+    const options = { ...validOptions };
 
     it('Fails with null', () =>
       assert.equal(validation({ ...options, query: null }), false));

--- a/src/validation.test.js
+++ b/src/validation.test.js
@@ -3,7 +3,7 @@ import { isValid } from './validation'
 
 const validation = isValid;
 
-describe('Options Validation', function() {
+describe('Options Validation', () => {
   const validOptions = {
     connection: 'localhost:9200',
     typeName: 'testName',
@@ -13,68 +13,126 @@ describe('Options Validation', function() {
     scrollSize: 999,
   }
 
-  it('validates the typeName field', function() {
+  describe('Validates the typeName field', () => {
     const options = Object.assign({}, validOptions);
     delete options.typeName;
 
-    assert.equal(validation(options), false)
-    assert.equal(validation(Object.assign({}, options, { typeName: null })), false)
-    assert.equal(validation(Object.assign({}, options, { typeName: '' })), false)
-    assert.equal(validation(Object.assign({}, options, { typeName: 'test' })), true)
+    it('Fails with no typeName', () =>
+      assert.equal(validation(options), false));
+
+    it('Fails with null', () =>
+      assert.equal(validation(Object.assign({}, options, { typeName: null })), false));
+
+    it('Fails with empty string', () =>
+    assert.equal(validation(Object.assign({}, options, { typeName: '' })), false));
+
+    it('Succeed with non-empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { typeName: 'test' })), true));
+
   });
 
-  it('validates the index field', function() {
+  describe('Validates the index field', () => {
     const options = Object.assign({}, validOptions);
     delete options.index;
 
-    assert.equal(validation(options), false)
-    assert.equal(validation(Object.assign({}, options, { index: null })), false)
-    assert.equal(validation(Object.assign({}, options, { index: '' })), false)
-    assert.equal(validation(Object.assign({}, options, { index: 'test' })), true)
+    it('Fails with no index', () =>
+      assert.equal(validation(options), false));
+
+    it('Fails with null', () =>
+      assert.equal(validation(Object.assign({}, options, { index: null })), false));
+
+    it('Fails with empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { index: '' })), false));
+
+    it('Succeed with non-empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { index: 'test' })), true));
+
   });
-  
-  it('validates the query field', function() {
+
+  describe('Validates the query field', () => {
     const options = Object.assign({}, validOptions);
     delete options.query;
 
-    // assert.equal(validation(options), false)
-    assert.equal(validation(Object.assign({}, options, { query: null })), false)
-    assert.equal(validation(Object.assign({}, options, { query: '' })), true)
-    assert.equal(validation(Object.assign({}, options, { query: 'test' })), true)
-    assert.equal(validation(Object.assign({}, options, { query: { test: 'this' } })), true)
+    // it('Fails with no query', () =>
+    //   assert.equal(validation(options), false));
+
+    it('Fails with null', () =>
+      assert.equal(validation(Object.assign({}, options, { query: null })), false));
+
+    it('Succeed with empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { query: '' })), true));
+
+    it('Succeed with non-empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { query: 'test' })), true));
+
+    it('Succeed with object', () =>
+      assert.equal(validation(Object.assign({}, options, { query: { test: 'this' } })), true));
+
   });
 
-  it('validates the connection field', function() {
+  describe('Validates the connection field', () => {
     const options = Object.assign({}, validOptions);
     delete options.connection;
 
-    assert.equal(validation(options), false)
-    assert.equal(validation(Object.assign({}, options, { connection: null })), false)
-    assert.equal(validation(Object.assign({}, options, { connection: '' })), false)
-    assert.equal(validation(Object.assign({}, options, { connection: 'localhost:9200' })), true)
-    assert.equal(validation(Object.assign({}, options, { connection: { host: 'localhost:9200' } })), true)
+    it('Fails with no connection', () =>
+      assert.equal(validation(options), false));
+
+    it('Fails with null', () =>
+      assert.equal(validation(Object.assign({}, options, { connection: null })), false));
+
+    it('Fails with empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { connection: '' })), false));
+
+    it('Succeed with non-empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { connection: 'localhost:9200' })), true));
+
+    it('Succeed with object', () =>
+      assert.equal(validation(Object.assign({}, options, { connection: { host: 'localhost:9200' } })), true));
+
   });
 
-  it('validates the scrollDuration field', function() {
+  describe('Validates the scrollDuration field', () => {
     const options = Object.assign({}, validOptions);
     delete options.scrollDuration;
 
-    assert.equal(validation(options), true) // not required
-    assert.equal(validation(Object.assign({}, options, { scrollDuration: null })), true) // not required
-    assert.equal(validation(Object.assign({}, options, { scrollDuration: '' })), true) // not required
-    assert.equal(validation(Object.assign({}, options, { scrollDuration: 'sdf' })), true)
-    assert.equal(validation(Object.assign({}, options, { scrollDuration: '1m' })), true)
-    assert.equal(validation(Object.assign({}, options, { scrollDuration: 123 })), false)
+    it('Succeed with no scrollDuration', () =>
+      assert.equal(validation(options), true)); // not required
+
+    it('Succeed with null', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollDuration: null })), true)); // not required
+
+    it('Succeed with empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollDuration: '' })), true)); // not required
+
+    it('Succeed with non-empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollDuration: 'sdf' })), true));
+
+    it('Succeed with object', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollDuration: '1m' })), true));
+
+    it('Fails with integer', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollDuration: 123 })), false));
+
   });
 
-  it('validates the scrollSize field', function() {
+  describe('Validates the scrollSize field', () => {
     const options = Object.assign({}, validOptions);
     delete options.scrollSize;
 
-    assert.equal(validation(options), true) // not required
-    assert.equal(validation(Object.assign({}, options, { scrollSize: null })), true) // not required
-    assert.equal(validation(Object.assign({}, options, { scrollSize: '' })), true) // not required
-    assert.equal(validation(Object.assign({}, options, { scrollSize: 'sdf' })), false)
-    assert.equal(validation(Object.assign({}, options, { scrollSize: 123 })), true)
+    it('Succeed with no scrollSize', () =>
+      assert.equal(validation(options), true)); // not required
+
+    it('Succeed with null', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollSize: null })), true)); // not required
+
+    it('Succeed with empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollSize: '' })), true)); // not required
+
+    it('Succeed with non-empty string', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollSize: 'sdf' })), false));
+
+    it('Fails with integer', () =>
+      assert.equal(validation(Object.assign({}, options, { scrollSize: 123 })), true));
+
   });
 });

--- a/src/validation.test.js
+++ b/src/validation.test.js
@@ -35,7 +35,7 @@ describe('Options Validation', function() {
     const options = Object.assign({}, validOptions);
     delete options.query;
 
-    assert.equal(validation(options), false)
+    // assert.equal(validation(options), false)
     assert.equal(validation(Object.assign({}, options, { query: null })), false)
     assert.equal(validation(Object.assign({}, options, { query: '' })), true)
     assert.equal(validation(Object.assign({}, options, { query: 'test' })), true)

--- a/src/validation.test.js
+++ b/src/validation.test.js
@@ -14,125 +14,125 @@ describe('Options Validation', () => {
   }
 
   describe('Validates the typeName field', () => {
-    const options = Object.assign({}, validOptions);
+    const options = { ...validOptions };
     delete options.typeName;
 
     it('Fails with no typeName', () =>
       assert.equal(validation(options), false));
 
     it('Fails with null', () =>
-      assert.equal(validation(Object.assign({}, options, { typeName: null })), false));
+      assert.equal(validation({ ...options, typeName: null }), false));
 
     it('Fails with empty string', () =>
-    assert.equal(validation(Object.assign({}, options, { typeName: '' })), false));
+    assert.equal(validation({ ...options, typeName: '' }), false));
 
     it('Succeed with non-empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { typeName: 'test' })), true));
+      assert.equal(validation({ ...options, typeName: 'test' }), true));
 
   });
 
   describe('Validates the index field', () => {
-    const options = Object.assign({}, validOptions);
+    const options = { ...validOptions };
     delete options.index;
 
     it('Fails with no index', () =>
       assert.equal(validation(options), false));
 
     it('Fails with null', () =>
-      assert.equal(validation(Object.assign({}, options, { index: null })), false));
+      assert.equal(validation({ ...options, index: null }), false));
 
     it('Fails with empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { index: '' })), false));
+      assert.equal(validation({ ...options, index: '' }), false));
 
     it('Succeed with non-empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { index: 'test' })), true));
+      assert.equal(validation({ ...options, index: 'test' }), true));
 
   });
 
   describe('Validates the query field', () => {
-    const options = Object.assign({}, validOptions);
+    const options = { ...validOptions };
     delete options.query;
 
     // it('Fails with no query', () =>
     //   assert.equal(validation(options), false));
 
     it('Fails with null', () =>
-      assert.equal(validation(Object.assign({}, options, { query: null })), false));
+      assert.equal(validation({ ...options, query: null }), false));
 
     it('Succeed with empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { query: '' })), true));
+      assert.equal(validation({ ...options, query: '' }), true));
 
     it('Succeed with non-empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { query: 'test' })), true));
+      assert.equal(validation({ ...options, query: 'test' }), true));
 
     it('Succeed with object', () =>
-      assert.equal(validation(Object.assign({}, options, { query: { test: 'this' } })), true));
+      assert.equal(validation({ ...options, query: { test: 'this' } }), true));
 
   });
 
   describe('Validates the connection field', () => {
-    const options = Object.assign({}, validOptions);
+    const options = { ...validOptions };
     delete options.connection;
 
     it('Fails with no connection', () =>
       assert.equal(validation(options), false));
 
     it('Fails with null', () =>
-      assert.equal(validation(Object.assign({}, options, { connection: null })), false));
+      assert.equal(validation({ ...options, connection: null }), false));
 
     it('Fails with empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { connection: '' })), false));
+      assert.equal(validation({ ...options, connection: '' }), false));
 
     it('Succeed with non-empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { connection: 'localhost:9200' })), true));
+      assert.equal(validation({ ...options, connection: 'localhost:9200' }), true));
 
     it('Succeed with object', () =>
-      assert.equal(validation(Object.assign({}, options, { connection: { host: 'localhost:9200' } })), true));
+      assert.equal(validation({ ...options, connection: { host: 'localhost:9200' } }), true));
 
   });
 
   describe('Validates the scrollDuration field', () => {
-    const options = Object.assign({}, validOptions);
+    const options = { ...validOptions };
     delete options.scrollDuration;
 
     it('Succeed with no scrollDuration', () =>
       assert.equal(validation(options), true)); // not required
 
     it('Succeed with null', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollDuration: null })), true)); // not required
+      assert.equal(validation({ ...options, scrollDuration: null }), true)); // not required
 
     it('Succeed with empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollDuration: '' })), true)); // not required
+      assert.equal(validation({ ...options, scrollDuration: '' }), true)); // not required
 
     it('Succeed with non-empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollDuration: 'sdf' })), true));
+      assert.equal(validation({ ...options, scrollDuration: 'sdf' }), true));
 
     it('Succeed with object', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollDuration: '1m' })), true));
+      assert.equal(validation({ ...options, scrollDuration: '1m' }), true));
 
     it('Fails with integer', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollDuration: 123 })), false));
+      assert.equal(validation({ ...options, scrollDuration: 123 }), false));
 
   });
 
   describe('Validates the scrollSize field', () => {
-    const options = Object.assign({}, validOptions);
+    const options = { ...validOptions };
     delete options.scrollSize;
 
     it('Succeed with no scrollSize', () =>
       assert.equal(validation(options), true)); // not required
 
     it('Succeed with null', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollSize: null })), true)); // not required
+      assert.equal(validation({ ...options, scrollSize: null }), true)); // not required
 
     it('Succeed with empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollSize: '' })), true)); // not required
+      assert.equal(validation({ ...options, scrollSize: '' }), true)); // not required
 
     it('Succeed with non-empty string', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollSize: 'sdf' })), false));
+      assert.equal(validation({ ...options, scrollSize: 'sdf' }), false));
 
     it('Fails with integer', () =>
-      assert.equal(validation(Object.assign({}, options, { scrollSize: 123 })), true));
+      assert.equal(validation({ ...options, scrollSize: 123 }), true));
 
   });
 });

--- a/validation.js
+++ b/validation.js
@@ -6,38 +6,46 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = validation;
 const isString = data => typeof data === 'string';
 
-const isEmptyString = data => data === '';
+const isValidString = data => isString(data) && data.length > 0;
 
 const isObject = data => typeof data === 'object';
 
-function validation(options) {
-  if (options.typeName == null || !isString(options.typeName) || isEmptyString(options.typeName)) {
-    console.log('Error: "typeName" option is required');
-    return false;
+function validation({
+  typeName,
+  connection,
+  index,
+  query,
+  scrollDuration,
+  scrollSize
+}) {
+  const errors = [];
+
+  if (!isValidString(typeName)) {
+    errors.push('Error: "typeName" option is required');
   }
 
-  if (options.connection == null || isString(options.connection) && isEmptyString(options.connection) && !isObject(options.connection)) {
-    console.log('Error: "connection" option must either be a non-empty string or an object');
-    return false;
+  if (!connection || !(isValidString(connection) || isObject(connection))) {
+    errors.push('Error: "connection" option must either be a non-empty string or an object');
   }
 
-  if (options.index == null || !isString(options.index) || isEmptyString(options.index)) {
-    console.log('Error: "index" option is required');
-    return false;
+  if (!isValidString(index)) {
+    errors.push('Error: "index" option is required');
   }
 
-  if (options.query == null || !isString(options.query) && !isObject(options.query)) {
-    console.log('Error: "query" must either be a string or an object');
-    return false;
+  if (query === null || !(isString(query) || isObject(query))) {
+    errors.push('Error: "query" must either be a string or an object');
   }
 
-  if (options.scrollDuration && !isString(options.scrollDuration)) {
-    console.log('Error: "scrollDuration" must be a duration string (i.e. 1s, 10s, 1m)');
-    return false;
+  if (scrollDuration && !isValidString(scrollDuration)) {
+    errors.push('Error: "scrollDuration" must be a duration string (i.e. 1s, 10s, 1m)');
   }
 
-  if (options.scrollSize && isNaN(parseFloat(options.scrollSize)) && !isFinite(options.scrollSize)) {
-    console.log('Error: "scrollSize" must be a number');
+  if (scrollSize && !isFinite(scrollSize)) {
+    errors.push('Error: "scrollSize" must be a number');
+  }
+
+  if (errors.length) {
+    errors.forEach(error => console.log(error));
     return false;
   }
 

--- a/validation.js
+++ b/validation.js
@@ -9,11 +9,14 @@ const isValidString = data => isString(data) && data.length > 0;
 
 const isObject = data => typeof data === 'object';
 
-const validator = ({
+const isDefined = data => typeof data !== 'undefined';
+
+const validator = exports.validator = ({
   typeName,
   connection,
   index,
   query,
+  body,
   scrollDuration,
   scrollSize
 }) => {
@@ -31,8 +34,20 @@ const validator = ({
     errors.push('Error: "index" option is required');
   }
 
-  if (query === null || !(isString(query) || isObject(query))) {
+  if (isString(query) && isObject(query) || query === null && !isDefined(body)) {
     errors.push('Error: "query" must either be a string or an object');
+  }
+
+  if (isDefined(query) && isDefined(body)) {
+    errors.push('Error: "query" and "body" are mutually exclusive');
+  }
+
+  if (!isDefined(query) && !isDefined(body)) {
+    errors.push('Error: "query" or "body" is required');
+  }
+
+  if (isDefined(body) && !isObject(body) || body === null && !isDefined(query)) {
+    errors.push('Error: "body" should be an object');
   }
 
   if (scrollDuration && !isValidString(scrollDuration)) {

--- a/validation.js
+++ b/validation.js
@@ -4,28 +4,34 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = validation;
+const isString = data => typeof data === 'string';
+
+const isEmptyString = data => data === '';
+
+const isObject = data => typeof data === 'object';
+
 function validation(options) {
-  if (options.typeName == null || typeof options.typeName !== 'string' || options.typeName === '') {
+  if (options.typeName == null || !isString(options.typeName) || isEmptyString(options.typeName)) {
     console.log('Error: "typeName" option is required');
     return false;
   }
 
-  if (options.connection == null || typeof options.connection === 'string' && options.connection === '' && typeof options.connection !== 'object') {
+  if (options.connection == null || isString(options.connection) && isEmptyString(options.connection) && !isObject(options.connection)) {
     console.log('Error: "connection" option must either be a non-empty string or an object');
     return false;
   }
 
-  if (options.index == null || typeof options.index !== 'string' || options.index === '') {
+  if (options.index == null || !isString(options.index) || isEmptyString(options.index)) {
     console.log('Error: "index" option is required');
     return false;
   }
 
-  if (options.query == null || typeof options.query !== 'string' && typeof options.query !== 'object') {
+  if (options.query == null || !isString(options.query) && !isObject(options.query)) {
     console.log('Error: "query" must either be a string or an object');
     return false;
   }
 
-  if (options.scrollDuration && typeof options.scrollDuration !== 'string') {
+  if (options.scrollDuration && !isString(options.scrollDuration)) {
     console.log('Error: "scrollDuration" must be a duration string (i.e. 1s, 10s, 1m)');
     return false;
   }

--- a/validation.js
+++ b/validation.js
@@ -57,4 +57,6 @@ const validation = exports.validation = options => {
   return true;
 };
 
+const isValid = exports.isValid = options => !validator(options).length;
+
 exports.default = validation;

--- a/validation.js
+++ b/validation.js
@@ -3,21 +3,20 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = validation;
 const isString = data => typeof data === 'string';
 
 const isValidString = data => isString(data) && data.length > 0;
 
 const isObject = data => typeof data === 'object';
 
-function validation({
+const validator = ({
   typeName,
   connection,
   index,
   query,
   scrollDuration,
   scrollSize
-}) {
+}) => {
   const errors = [];
 
   if (!isValidString(typeName)) {
@@ -44,10 +43,18 @@ function validation({
     errors.push('Error: "scrollSize" must be a number');
   }
 
+  return errors;
+};
+
+const validation = exports.validation = options => {
+  const errors = validator(options);
+
   if (errors.length) {
     errors.forEach(error => console.log(error));
     return false;
   }
 
   return true;
-}
+};
+
+exports.default = validation;


### PR DESCRIPTION
This allows to do Elasticsearch [Request Body Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html) with [Source filtering](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html) or [sorting](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html).