### PR TITLE
add type of objects to the plugin options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules
 .DS_Store
 yarn-error.log
+/.idea/*
+/*.iml
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ yarn add gatsby-source-elasticsearch
 | --- | --- | --- |
 | connection | Connection details | string, object |
 | index | The index to query against | string |
+| type | The object type of query (optional) | string |
 | typeName | The type name to generate in Gatsby | string |
 | query | The query as query string to run | string, object |
 | body | The [query body](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html) to run | object |

--- a/query.js
+++ b/query.js
@@ -10,9 +10,10 @@ const isString = data => typeof data === 'string';
 
 const isObject = data => typeof data === 'object';
 
-exports.default = ({ index, scrollDuration, scrollSize, query, body }) => {
+exports.default = ({ index, scrollDuration, scrollSize, query, body, type }) => {
   const result = {
     index,
+    type,
     scroll: scrollDuration || '30s',
     size: scrollSize || 1000
   };

--- a/src/query.js
+++ b/src/query.js
@@ -4,9 +4,10 @@ const isString = data =>
 const isObject = data =>
   typeof data === 'object';
 
-export default ({ index, scrollDuration, scrollSize, query, body }) => {
+export default ({ index, scrollDuration, scrollSize, query, body, type }) => {
   const result = {
     index,
+    type,
     scroll: scrollDuration || '30s',
     size: scrollSize || 1000,
   }

--- a/src/validation.js
+++ b/src/validation.js
@@ -14,6 +14,7 @@ export const validator = ({
   typeName,
   connection,
   index,
+  type,
   query,
   body,
   scrollDuration,
@@ -55,6 +56,10 @@ export const validator = ({
 
   if (scrollSize && !isFinite(scrollSize)) {
     errors.push('Error: "scrollSize" must be a number');
+  }
+
+  if (isDefined(type) && !isValidString(type)) {
+    errors.push('Error: "type" is optional and if exists must either be a string');
   }
 
   return errors;

--- a/validation.js
+++ b/validation.js
@@ -15,6 +15,7 @@ const validator = exports.validator = ({
   typeName,
   connection,
   index,
+  type,
   query,
   body,
   scrollDuration,
@@ -56,6 +57,10 @@ const validator = exports.validator = ({
 
   if (scrollSize && !isFinite(scrollSize)) {
     errors.push('Error: "scrollSize" must be a number');
+  }
+
+  if (isDefined(type) && !isValidString(type)) {
+    errors.push('Error: "type" is optional and if exists must either be a string');
   }
 
   return errors;


### PR DESCRIPTION
the query together with the type of the object

sample config:

`{
            resolve: 'gatsby-source-elasticsearch',
            options: {
                connection: {
                    host: 'http://localhost:9200',
                    log: 'debug',
                },
                index: 'xyz',
                type: 'documentfields',
                typeName: 'documentfields',
                body: {
                    _source: ["uuid", "map", "document"],
                    query: {
                        "constant_score" : {
                            "filter" : {
                                "exists" : {
                                    "field" : "fields"
                                }
                            }
                        }
                    }
                },
            },
        }`

elastic query:
`Elasticsearch DEBUG: 2019-07-16T20:02:44Z
  starting request {
    "method": "POST",
    "path": "/xyz/documentfields/_search",
    "body": {
      "_source": [
        "uuid",
        "map",
        "document"
      ],
      "query": {
        "constant_score": {
          "filter": {
            "exists": {
              "field": "fields"
            }
          }
        }
      }
    },
    "query": {
      "scroll": "30s",
      "size": 1000
    }
  }`
